### PR TITLE
indexing and selection of valid patterns from folder 

### DIFF
--- a/pattern_video.m
+++ b/pattern_video.m
@@ -60,7 +60,9 @@ if isempty(ext)
         patfile(pidx) = isValidPatternFile(fullfile(filepath,filelist.mat{pidx}));
     end
     assert(any(patfile),'no pattern files found in folder')
-    patfilenames = filelist.mat(patfile);
+    potentialfiles = (1:length(patfile));
+    patfile = logical(patfile);
+    patfilenames = filelist.mat(potentialfiles(patfile));
     pathnames = cellstr(repmat(filepath,size(patfilenames,1),1));
     
     Pats = fullfile(pathnames,patfilenames);

--- a/pattern_video.m
+++ b/pattern_video.m
@@ -55,14 +55,12 @@ if isempty(ext)
     filelist = what(fullfile(filepath));
     assert(~isempty(filelist.mat),'input folder should contain Pattern_*.mat file(s)')
     
-    patfile = zeros(1,length(filelist.mat));
+    patfile = []; % will be filled with logicals.. don't initialize with doubles or other format
     for pidx = 1:length(filelist.mat)
         patfile(pidx) = isValidPatternFile(fullfile(filepath,filelist.mat{pidx}));
     end
     assert(any(patfile),'no pattern files found in folder')
-    potentialfiles = (1:length(patfile));
-    patfile = logical(patfile);
-    patfilenames = filelist.mat(potentialfiles(patfile));
+    patfilenames = filelist.mat(patfile);
     pathnames = cellstr(repmat(filepath,size(patfilenames,1),1));
     
     Pats = fullfile(pathnames,patfilenames);


### PR DESCRIPTION
Bug: 
if patfile = [1 1 1 1 1]
patfilenames was selecting only the first pattern file in a folder, rather than each of the validated pattern files.
Fix: 
indexed all the pattern files found in the folder (potentialfiles Eg: [1 2 3 4 5]) and then used the logical patfiles matrix to pick out the validated patterns. 

Test on this directory
Y:\Martha\MagnoExperiments_Patterns\